### PR TITLE
Update manifest.json to fix installation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "developer_name": "NoXPhasma",
     "icon": "icon.svg",
     "options": {
-        "query_debounce": 1
+        "query_debounce": 1.0
     },
     "preferences": [
         {


### PR DESCRIPTION
When attempting to install the plugin into ulauncher, it complained about the "query_debounce" being a int when it expected a float. This PR makes the field in question into a float.

The error when attempting to install the plugin:
```
2023-10-04 20:39:22,385 ⚠  ERROR Preferences server error: KeyError preferences_server.request_listener:122
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/ulauncher/ui/preferences_server.py", line 118, in request_listener
    data = json.dumps([route_handler(self, *args)])
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/ulauncher/ui/preferences_server.py", line 266, in extension_add
    ext_id = downloader.download(url)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/ulauncher/modes/extensions/ExtensionDownloader.py", line 32, in download
    remote.download()
  File "/usr/lib/python3.11/site-packages/ulauncher/modes/extensions/ExtensionRemote.py", line 188, in download
    manifest = ExtensionManifest.load(f"{tmp_dir}/manifest.json")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/ulauncher/utils/json_conf.py", line 37, in load
    instance.update(data)
  File "/usr/lib/python3.11/site-packages/ulauncher/utils/basedataclass.py", line 80, in update
    self[k] = v
    ~~~~^^^
  File "/usr/lib/python3.11/site-packages/ulauncher/modes/extensions/ExtensionManifest.py", line 89, in __setitem__
    super().__setitem__(key, value)
  File "/usr/lib/python3.11/site-packages/ulauncher/utils/basedataclass.py", line 73, in __setitem__
    raise KeyError(msg)
KeyError: '"input_debounce" must be of type float, int given.'
```